### PR TITLE
Total dmvn

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: modsem
 Type: Package
 Title: Latent Interaction (and Moderation) Analysis in Structural Equation Models (SEM)
-Version: 1.0.7
+Version: 1.0.8
 Authors@R: 
     c(person(given = "Kjell", family = "Solem Slupphaug", 
              email = "slupphaugkjell@gmail.com", role = c("aut", "cre"),

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -53,3 +53,7 @@ dmvnrm_arma_mc <- function(x, mean, sigma, logd = TRUE) {
     .Call(`_modsem_dmvnrm_arma_mc`, x, mean, sigma, logd)
 }
 
+totalDmvnWeightedCpp <- function(mu, sigma, nu, S, tgamma, n, d) {
+    .Call(`_modsem_totalDmvnWeightedCpp`, mu, sigma, nu, S, tgamma, n, d)
+}
+

--- a/R/calc_se_da.R
+++ b/R/calc_se_da.R
@@ -195,8 +195,9 @@ calcEFIM_LMS <- function(model, finalModel = NULL, theta, data, S = 3e4,
       sub <- n1:nn
     } else sub <- sample(R, N)
 
+    P <- estepLms(model = model, theta=theta, data = population[sub, ])
     J <- gradientLogLikLms(theta = theta, model = model, data = population[sub, ],
-                           P = P[sub, ], sign = 1, epsilon = epsilon)
+                                  P = P, sign = 1, epsilon = epsilon)
 
     I <- I + J %*% t(J)
   }

--- a/R/equations_lms.R
+++ b/R/equations_lms.R
@@ -76,47 +76,32 @@ estepLms <- function(model, theta, data, ...) {
   # probability of observing the data given the nodes, and what is the probability
   # of observing the given nodes (i.e., w). Sum the row probabilities = 1
   P <- matrix(0, nrow = nrow(data), ncol = length(w))
-  sapply(seq_along(w), FUN = function(i) {
-    P[, i] <<- w[[i]] * dmvn(data,
-      mean = muLmsCpp(model = modFilled, z = V[i, ]),
-      sigma = sigmaLmsCpp(model = modFilled, z = V[i, ]),
-      log = FALSE
-    )
-  })
-  P / rowSums(P)
-}
 
+  for (i in seq_along(w)) {
+    P[, i] <- dmvn(data, mean = muLmsCpp(model = modFilled, z = V[i, ]),
+                   sigma = sigmaLmsCpp(model = modFilled, z = V[i, ]),
+                   log = FALSE) * w[[i]]
+  }
 
-total_dmvn_weighted <- function(X, mu, sigma, gamma) {
-  # X: n x d matrix of data
-  # mu: d-dimensional mean vector
-  # sigma: d x d covariance matrix
-  # gamma: n-dimensional vector of weights
-
-  n <- nrow(X)
-  d <- ncol(X)
+  P <- P / rowSums(P)
   
-  Gamma <- sum(gamma)
-  
-  # Weighted mean
-  x_bar <- colSums(X * gamma) / Gamma
+  wMeans <- vector("list", length = length(w))
+  wCovs  <- vector("list", length = length(w))
+  tGamma <- vector("list", length = length(w))
 
-  # Weighted scatter matrix
-  X_centered <- X - matrix(x_bar, n, d, byrow = TRUE)
-  S_gamma <- t(X_centered) %*% (X_centered * gamma)
+  for (i in seq_along(w)) {
+    p    <- P[, i]
+    wm   <- colSums(data * p) / sum(p)
+    X    <- data - matrix(wm, nrow=nrow(data), ncol=ncol(data), byrow=TRUE)
+    wcov <- t(X) %*% (X * p)
 
-  # Inverse and determinant
-  sigma_inv <- solve(sigma)
-  log_det_sigma <- determinant(sigma, logarithm = TRUE)$modulus
+    P[, i]      <- p
+    wMeans[[i]] <- wm
+    wCovs[[i]]  <- wcov
+    tGamma[[i]] <- sum(p)
+  }
 
-  # Quadratic terms
-  trace_term <- sum(sigma_inv * S_gamma)
-  mean_diff <- matrix(x_bar - mu, nrow = 1)
-  mahalanobis_term <- Gamma * (mean_diff %*% sigma_inv %*% t(mean_diff))
-
-  # Final log-likelihood
-  log_likelihood <- -0.5 * (Gamma * d * log(2 * pi) + Gamma * log_det_sigma + trace_term + mahalanobis_term)
-  as.numeric(log_likelihood)
+  list(P = P, mean = wMeans, cov = wCovs, tgamma = tGamma)
 }
 
 
@@ -124,26 +109,19 @@ logLikLms <- function(theta, model, data, P, sign = -1, ...) {
   modFilled <- fillModel(model = model, theta = theta, method = "lms")
   k <- model$quad$k
   V <- modFilled$quad$n
+  n <- nrow(data)
+  d <- ncol(data)
   # summed log probability of observing the data given the parameters
   # weighted my the posterior probability calculated in the E-step
-  r <- vapply(seq_len(nrow(V)), FUN.VALUE = numeric(1L), FUN = function(i) {
-    lls <- sum(dmvn(data,
-      mean = muLmsCpp(model = modFilled, z = V[i, ]),
-      sigma = sigmaLmsCpp(model = modFilled, z = V[i, ]),
-      log = TRUE
-    ) * P[, i])
-    lls
-    lls2 <- total_dmvn_weighted(X = data,
-      mu = muLmsCpp(model = modFilled, z = V[i, ]),
-      sigma = sigmaLmsCpp(model = modFilled, z = V[i, ]),
-      gamma = P[, i])
+  r_2 <- vapply(seq_len(nrow(V)), FUN.VALUE = numeric(1L), FUN = function(i) {
+    totalDmvnWeightedCpp(mu=muLmsCpp(model=modFilled, z=V[i, ]),
+                         sigma=sigmaLmsCpp(model=modFilled, z=V[i, ]), 
+                         nu=P$mean[[i]], S=P$cov[[i]], tgamma=P$tgamma[[i]], 
+                         n = n, d = d)
 
-    lls2
+  })
 
-    if (round(lls2, 6) != round(lls, 6)) browser()
-    lls2
-  }) |> sum()
-  sign * r
+  sign * sum(r_2)
 }
 
 
@@ -161,6 +139,7 @@ logLikLms_i <- function(theta, model, data, P, sign = -1, ...) {
   modFilled <- fillModel(model = model, theta = theta, method = "lms")
   k <- model$quad$k
   V <- modFilled$quad$n
+  P <- P$P
   # summed log probability of observing the data given the parameters
   # weighted my the posterior probability calculated in the E-step
   r <- lapplyMatrix(seq_len(nrow(V)), FUN = function(i) {

--- a/R/equations_qml.R
+++ b/R/equations_qml.R
@@ -81,12 +81,11 @@ logLikQml <- function(theta, model, sum = TRUE, sign = -1, verbose = FALSE) {
   indsY         <- colnames(m$y)
   nonNormalInds <- indsY[!indsY %in% normalInds]
 
-  f2 <- probf2(matrices = m, normalInds = normalInds, sigma = sigmaXU)
+  f2 <- probf2(matrices = m, normalInds = normalInds, sigma = sigmaXU, sum = sum)
   f3 <- probf3(matrices = m, nonNormalInds = nonNormalInds, expected = Ey,
-               sigma = sigmaEpsilon, t = t, numEta = numEta)
+               sigma = sigmaEpsilon, t = t, numEta = numEta, sum = sum)
 
-  if (sum) logLik <- sum(f2 + f3)
-  else     logLik <- (f2 + f3)
+  logLik <- (f2 + f3)
 
   if (verbose) incrementIterations(logLik)
 
@@ -100,19 +99,53 @@ calcSigmaXU <- function(matrices) {
 }
 
 
-probf2 <- function(matrices, normalInds, sigma) {
+probf2 <- function(matrices, normalInds, sigma, sum=FALSE) {
   mu <- rep(0, ncol(sigma))
   X  <- cbind(matrices$x, matrices$u)[ , normalInds]
-  dmvn(X, mean = mu, sigma = sigma, log = TRUE)
+
+  if (sum)
+    total_log_dmvn(X, mu = mu, sigma = sigma)
+  else
+    dmvn(X, mean = mu, sigma = sigma, log = TRUE)
+
 }
 
 
-probf3 <- function(matrices, nonNormalInds, expected, sigma, t, numEta) {
-  if (numEta == 1) {
-    return(dnormCpp(matrices$y[, 1], mu = expected, sigma = sqrt(sigma)))
-  }
-  rep_dmvnorm(matrices$y[, nonNormalInds], expected = expected,
+total_log_dmvn <- function(X, mu, sigma) {
+  # X: n x d matrix of observations (rows = samples, cols = features)
+  # mu: d-dimensional mean vector
+  # sigma: d x d covariance matrix
+
+  n <- nrow(X)
+  d <- ncol(X)
+  
+  # Compute empirical mean and scatter matrix
+  x_bar <- colMeans(X)
+  S <- t(X - matrix(x_bar, n, d, byrow = TRUE)) %*% (X - matrix(x_bar, n, d, byrow = TRUE))
+  
+  # Inverse and determinant of sigma
+  sigma_inv <- solve(sigma)
+  log_det_sigma <- determinant(sigma, logarithm = TRUE)$modulus
+  
+  # Compute quadratic terms
+  trace_term <- sum(sigma_inv * S)  # Efficient trace of product
+  mean_diff <- matrix(x_bar - mu, nrow = 1)
+  mahalanobis_term <- n * (mean_diff %*% sigma_inv %*% t(mean_diff))
+
+  # Final log-likelihood
+  log_likelihood <- -0.5 * (n * d * log(2 * pi) + n * log_det_sigma + trace_term + mahalanobis_term)
+  return(as.numeric(log_likelihood))
+}
+
+
+probf3 <- function(matrices, nonNormalInds, expected, sigma, t, numEta, sum = FALSE) {
+  if (numEta == 1)
+    p <- dnormCpp(matrices$y[, 1], mu = expected, sigma = sqrt(sigma))
+  else 
+    p <- rep_dmvnorm(matrices$y[, nonNormalInds], expected = expected,
               sigma = sigma, t = t)
+
+  if (sum) sum(p) else p
 }
 
 

--- a/R/equations_qml.R
+++ b/R/equations_qml.R
@@ -103,48 +103,25 @@ probf2 <- function(matrices, normalInds, sigma, sum=FALSE) {
   mu <- rep(0, ncol(sigma))
   X  <- cbind(matrices$x, matrices$u)[ , normalInds]
 
-  if (sum)
-    total_log_dmvn(X, mu = mu, sigma = sigma)
-  else
-    dmvn(X, mean = mu, sigma = sigma, log = TRUE)
+  # if (sum)
+  #   total_log_dmvn(X, mu = mu, sigma = sigma)
+  # else
+  #  dmvn(X, mean = mu, sigma = sigma, log = TRUE)
 
+  p <- dmvn(X, mean = mu, sigma = sigma, log = TRUE)
+
+  if (sum) sum(p) else p
 }
 
 
-total_log_dmvn <- function(X, mu, sigma) {
-  # X: n x d matrix of observations (rows = samples, cols = features)
-  # mu: d-dimensional mean vector
-  # sigma: d x d covariance matrix
-
-  n <- nrow(X)
-  d <- ncol(X)
-  
-  # Compute empirical mean and scatter matrix
-  x_bar <- colMeans(X)
-  S <- t(X - matrix(x_bar, n, d, byrow = TRUE)) %*% (X - matrix(x_bar, n, d, byrow = TRUE))
-  
-  # Inverse and determinant of sigma
-  sigma_inv <- solve(sigma)
-  log_det_sigma <- determinant(sigma, logarithm = TRUE)$modulus
-  
-  # Compute quadratic terms
-  trace_term <- sum(sigma_inv * S)  # Efficient trace of product
-  mean_diff <- matrix(x_bar - mu, nrow = 1)
-  mahalanobis_term <- n * (mean_diff %*% sigma_inv %*% t(mean_diff))
-
-  # Final log-likelihood
-  log_likelihood <- -0.5 * (n * d * log(2 * pi) + n * log_det_sigma + trace_term + mahalanobis_term)
-  return(as.numeric(log_likelihood))
-}
 
 
 probf3 <- function(matrices, nonNormalInds, expected, sigma, t, numEta, sum = FALSE) {
-  if (numEta == 1)
+  if (numEta == 1) 
     p <- dnormCpp(matrices$y[, 1], mu = expected, sigma = sqrt(sigma))
   else 
     p <- rep_dmvnorm(matrices$y[, nonNormalInds], expected = expected,
               sigma = sigma, t = t)
-
   if (sum) sum(p) else p
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -160,6 +160,23 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// totalDmvnWeightedCpp
+double totalDmvnWeightedCpp(const arma::vec& mu, const arma::mat& sigma, const arma::vec& nu, const arma::mat& S, double tgamma, int n, int d);
+RcppExport SEXP _modsem_totalDmvnWeightedCpp(SEXP muSEXP, SEXP sigmaSEXP, SEXP nuSEXP, SEXP SSEXP, SEXP tgammaSEXP, SEXP nSEXP, SEXP dSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const arma::vec& >::type mu(muSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type sigma(sigmaSEXP);
+    Rcpp::traits::input_parameter< const arma::vec& >::type nu(nuSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type S(SSEXP);
+    Rcpp::traits::input_parameter< double >::type tgamma(tgammaSEXP);
+    Rcpp::traits::input_parameter< int >::type n(nSEXP);
+    Rcpp::traits::input_parameter< int >::type d(dSEXP);
+    rcpp_result_gen = Rcpp::wrap(totalDmvnWeightedCpp(mu, sigma, nu, S, tgamma, n, d));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_modsem_calcSESimpleSlopes", (DL_FUNC) &_modsem_calcSESimpleSlopes, 2},
@@ -174,6 +191,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_modsem_multiplyIndicatorsCpp", (DL_FUNC) &_modsem_multiplyIndicatorsCpp, 1},
     {"_modsem_rep_dmvnorm", (DL_FUNC) &_modsem_rep_dmvnorm, 4},
     {"_modsem_dmvnrm_arma_mc", (DL_FUNC) &_modsem_dmvnrm_arma_mc, 4},
+    {"_modsem_totalDmvnWeightedCpp", (DL_FUNC) &_modsem_totalDmvnWeightedCpp, 7},
     {NULL, NULL, 0}
 };
 

--- a/src/equations_qml.cpp
+++ b/src/equations_qml.cpp
@@ -188,13 +188,14 @@ arma::vec logNormalPdf(const arma::vec& x, const arma::vec& mu, const arma::mat&
       result(i) += -0.5 * log_2pi - std::log(sigma(i, j)) - 0.5 * (diff * diff) / sigma_sq;
     }
   }
+
   return result;
 }
 
 
 // [[Rcpp::export]]
 arma::vec dnormCpp(const arma::vec& x, const arma::vec& mu, const arma::vec& sigma) {
-    return logNormalPdf(x, mu, sigma);
+  return logNormalPdf(x, mu, sigma);
 }
 
 

--- a/src/mvnorm.cpp
+++ b/src/mvnorm.cpp
@@ -73,17 +73,15 @@ double totalDmvnWeightedCpp(const arma::vec& mu,
                             double tgamma,
                             int n,
                             int d) {
+  if (!sigma.is_finite()) return NA_REAL;
+
   if (arma::any(arma::diagvec(sigma) <= 0)) return NA_REAL;
 
   arma::mat L;
-  bool success = arma::chol(L, sigma, "lower");
-
-  if (!success) return NA_REAL;
+  if (!arma::chol(L, sigma, "lower")) return NA_REAL;
 
   double log_det_sigma = 2.0 * arma::sum(log(L.diag()));
-
   arma::mat sigma_inv = arma::inv_sympd(sigma);
-
   if (!sigma_inv.is_finite()) return NA_REAL;
 
   arma::vec diff = nu - mu;


### PR DESCRIPTION
Since we use the total log likelihood as the objective function in the lms-approach, it is possible to make it more efficient by calculating the total directly from the mean-vector and covariance matrix, instead of for all individual data points. This leads to a substantial performance boost.