### PR TITLE
Handling of ordered variables in `modsem_da`

### DIFF
--- a/R/generics_modsem_pi.R
+++ b/R/generics_modsem_pi.R
@@ -384,7 +384,7 @@ print.modsem_pi <- function(x, ...) {
 }
 
 
-#' @describeIn modsem_predict
+#' @describeIn modsem_predict Wrapper for \code{lavaan::predict}
 #' @export
 modsem_predict.modsem_pi <- function(object, ...) {
   lavaan::predict(extract_lavaan(object), ...)

--- a/R/modsem_da.R
+++ b/R/modsem_da.R
@@ -301,11 +301,54 @@ modsem_da <- function(model.syntax = NULL,
   }
 
   if (length(ordered) || any(sapply(data, FUN = is.ordered))) {
-    data <- correctScaleOrdered(
-      model.syntax = model.syntax,
-      data         = data,
-      ordered      = ordered
-    )
+    out <- modsemOrderedScaleCorrection(
+       model.syntax        = model.syntax,
+       data                = data,
+       method              = method,
+       verbose             = verbose,
+       optimize            = optimize,
+       nodes               = nodes,
+       impute.na           = impute.na,
+       convergence.abs     = convergence.abs,
+       convergence.rel     = convergence.rel,
+       optimizer           = optimizer,
+       center.data         = center.data,
+       standardize.data    = standardize.data,
+       standardize.out     = standardize.out,
+       standardize         = standardize,
+       mean.observed       = mean.observed,
+       cov.syntax          = cov.syntax,
+       double              = double,
+       calc.se             = calc.se,
+       FIM                 = FIM,
+       EFIM.S              = EFIM.S,
+       OFIM.hessian        = OFIM.hessian,
+       EFIM.parametric     = EFIM.parametric,
+       robust.se           = robust.se,
+       R.max               = R.max,
+       max.iter            = max.iter,
+       max.step            = max.step,
+       start               = start,
+       epsilon             = epsilon,
+       quad.range          = quad.range,
+       adaptive.quad       = adaptive.quad,
+       adaptive.frequency  = adaptive.frequency,
+       adaptive.quad.tol   = adaptive.quad.tol,
+       n.threads           = n.threads,
+       algorithm           = algorithm,
+       em.control          = em.control,
+       ordered             = ordered,
+       rcs                 = rcs,
+       rcs.choose          = rcs.choose,
+       rcs.scale.corrected = rcs.scale.corrected,
+       orthogonal.x        = orthogonal.x,
+       orthogonal.y        = orthogonal.y,
+       auto.fix.first      = auto.fix.first,
+       auto.fix.single     = auto.fix.single,
+       auto.split.syntax   = auto.split.syntax,
+       ...)
+
+    return(out)
   }
 
   if (is.null(data)) {

--- a/R/modsem_da.R
+++ b/R/modsem_da.R
@@ -140,6 +140,9 @@
 #'
 #' @param em.control a list of control parameters for the EM algorithm. See \code{\link{default_settings_da}} for defaults.
 #'
+#' @param ordered Variables to be treated as ordered. Ordered (ordinal) variables are scale-corrected to adjust for 
+#'   unequal intervals before model estimation, using an ordered CFA.
+#'
 #' @param rcs Should latent variable indicators be replaced with reliability-corrected
 #'   single item indicators instead? See \code{\link{relcorr_single_item}}.
 #'
@@ -279,6 +282,7 @@ modsem_da <- function(model.syntax = NULL,
                       n.threads = NULL,
                       algorithm = NULL,
                       em.control = NULL,
+                      ordered = NULL,
                       rcs = FALSE,
                       rcs.choose = NULL,
                       rcs.scale.corrected = TRUE,
@@ -294,6 +298,14 @@ modsem_da <- function(model.syntax = NULL,
     stop2("The provided model syntax is not a string!")
   } else if (length(model.syntax) > 1) {
     stop2("The provided model syntax is not of length 1")
+  }
+
+  if (length(ordered) || any(sapply(data, FUN = is.ordered))) {
+    data <- correctScaleOrdered(
+      model.syntax = model.syntax,
+      data         = data,
+      ordered      = ordered
+    )
   }
 
   if (is.null(data)) {

--- a/R/modsem_da.R
+++ b/R/modsem_da.R
@@ -141,7 +141,10 @@
 #' @param em.control a list of control parameters for the EM algorithm. See \code{\link{default_settings_da}} for defaults.
 #'
 #' @param ordered Variables to be treated as ordered. Ordered (ordinal) variables are scale-corrected to adjust for 
-#'   unequal intervals before model estimation, using an ordered CFA.
+#'   unequal intervals before model estimation, by estimating the distributions of the underlying continuous response variables. 
+#'   The distributions of the response variables are estimated using a combination of bootstrapping and Monte Carlo simulations.
+#'   For small differences in the spacing of the intervals, the point estimates should be unbiased. The standard errors may be
+#'   underestimated though. Using robust standard errors may make the estimates of the standard errors more accurate.
 #'
 #' @param ordered.boot Number of bootstraps used to estimate the underlying continuous distribution of the
 #'   ordinal variables.

--- a/R/modsem_da.R
+++ b/R/modsem_da.R
@@ -143,6 +143,9 @@
 #' @param ordered Variables to be treated as ordered. Ordered (ordinal) variables are scale-corrected to adjust for 
 #'   unequal intervals before model estimation, using an ordered CFA.
 #'
+#' @param ordered.boot Number of bootstraps used to estimate the underlying continuous distribution of the
+#'   ordinal variables.
+#'
 #' @param rcs Should latent variable indicators be replaced with reliability-corrected
 #'   single item indicators instead? See \code{\link{relcorr_single_item}}.
 #'
@@ -283,6 +286,7 @@ modsem_da <- function(model.syntax = NULL,
                       algorithm = NULL,
                       em.control = NULL,
                       ordered = NULL,
+                      ordered.boot = 5,
                       rcs = FALSE,
                       rcs.choose = NULL,
                       rcs.scale.corrected = TRUE,
@@ -306,6 +310,7 @@ modsem_da <- function(model.syntax = NULL,
        data                = data,
        method              = method,
        verbose             = verbose,
+       R                   = ordered.boot,
        optimize            = optimize,
        nodes               = nodes,
        impute.na           = impute.na,

--- a/R/scale_correction_ordered.R
+++ b/R/scale_correction_ordered.R
@@ -29,7 +29,7 @@ correctScaleOrdered <- function(model.syntax, data = NULL, ordered = NULL, ...) 
       mu    <- (dnorm(t0) - dnorm(t1)) / (pnorm(t1) - pnorm(t0))
       z.mid <- qnorm((pnorm(t0) + pnorm(t1)) / 2)
 
-      y[x == level] <- mu
+      y[x == level] <- z.mid
     }
 
     if (mean.structure) offset <- mean(as.integer(as.factor(x)), na.rm = TRUE)
@@ -45,4 +45,107 @@ correctScaleOrdered <- function(model.syntax, data = NULL, ordered = NULL, ...) 
     data.y[[var]] <- rescaleVariable(data[[var]], name = var)
 
   data.y
+}
+
+
+modsemOrderedScaleCorrection <- function(model.syntax,
+                                         data,
+                                         method = "lms",
+                                         ordered = NULL,
+                                         calc.se = TRUE,
+                                         R = 5,
+                                         N = 1e5, # 100,000
+                                         verbose = interactive(),
+                                         ...) {
+  if (is.null(verbose))
+    verbose <- TRUE # default
+
+  cols <- colnames(data)
+  cols.ordered <- cols[cols %in% ordered | sapply(data, is.ordered)]
+
+  for (col in cols.ordered)
+    data[[col]] <- as.integer(as.ordered(data[[col]]))
+
+  rescaleOrderedVariable <- function(name, data, sim.ov) {
+    n <- NROW(data)
+    N <- NROW(sim.ov)
+
+    x <- as.integer(as.ordered(data[[name]]))
+    y <- sim.ov[, name]
+    y <- (y - mean(y)) / sd(y) # standardize
+    y <- round(y, 1)
+
+    exp.densities <- table(y) / N
+    exp.cdf <- cumsum(exp.densities)
+
+    obs.densities <- table(x) / n
+    obs.cdf <- cumsum(obs.densities)
+
+    out <- rep(NA, n)
+    for (i in seq_along(obs.cdf)) {
+      quantile <- obs.cdf[i]
+      match   <- exp.cdf[exp.cdf <= quantile]
+      exp.cdf <- exp.cdf[exp.cdf > quantile]
+
+      match.values <- as.numeric(names(match))
+
+      lower <- match.values[1L]
+      upper <- last(match.values)
+
+      mu <- mean(y[y >= lower & y <= upper])
+
+      out[!is.na(x) & x == i] <- mu 
+    }
+
+    out
+  }
+
+  rescaleOrderedData <- function(data, sim.ov) {
+    data.y <- data
+
+    for (col in cols.ordered)
+      data.y[[col]] <- rescaleOrderedVariable(name = col, data = data, 
+                                              sim.ov = sim.ov)
+
+    data.y
+  }
+
+
+  ERROR <- \(e) {warning2(e, immediate. = FALSE); NULL}
+
+  data.x <- data
+  data.y <- data
+  for (r in seq_len(R)) {
+    printedLines <- utils::capture.output(split = TRUE, {
+      if (verbose) printf("Bootstrapping scale-correction %d/%d...\n", r, R)
+
+      fit.naive <- modsem(
+        model.syntax = model.syntax,
+        data         = data.y,
+        method       = method,
+        calc.se      = FALSE,
+        verbose      = verbose,
+        ...
+      )
+
+      sim <- modsem:::simulateDataParTable(
+        parTable = parameter_estimates(fit.naive),
+        N        = N
+      )
+
+      data.y <- rescaleOrderedData(data = data.x, sim.ov = sim$oV)
+    })
+
+    nprinted <- length(printedLines)
+    eraseConsoleLines(nprinted)
+  }
+
+  modsem(
+    model.syntax = model.syntax, 
+    method       = method,
+    data         = data.y, 
+    calc.se      = calc.se,
+    verbose      = verbose,
+    ...
+  )
 }

--- a/R/scale_correction_ordered.R
+++ b/R/scale_correction_ordered.R
@@ -128,7 +128,7 @@ modsemOrderedScaleCorrection <- function(model.syntax,
         ...
       )
 
-      sim <- modsem:::simulateDataParTable(
+      sim <- simulateDataParTable(
         parTable = parameter_estimates(fit.naive),
         N        = N
       )

--- a/R/scale_correction_ordered.R
+++ b/R/scale_correction_ordered.R
@@ -1,0 +1,48 @@
+correctScaleOrdered <- function(model.syntax, data = NULL, ordered = NULL, ...) {
+  cols.ordered <- colnames(data) %in% ordered
+  data[cols.ordered] <- lapply(data[cols.ordered], FUN = as.ordered)
+
+  parTable  <- modsemify(model.syntax)
+  outer     <- parTable[parTable$op == "=~", ]
+  cfa.cat   <- lavaan::cfa(parTableToSyntax(outer), data = data, ...)
+  estimates <- parameterEstimates(cfa.cat)
+
+  thresholds <- estimates[estimates$op == "|", , drop = FALSE]
+
+  if (!NROW(thresholds))
+    return(data)
+
+  rescaleVariable <- function(x, name, mean.structure = TRUE) {
+    thresholds <- c(-Inf, sort(thresholds[thresholds$lhs == name, "est"]), Inf)
+    levels <- levels(x)
+
+    stopif(length(thresholds) != length(levels) + 1,
+           "Unexpected number of thresholds and ordered levels!")
+
+    y <- rep(NA, length(x))
+    for (i in seq_along(levels)) {
+      level <- levels(x)[[i]]
+
+      t0 <- thresholds[i]
+      t1 <- thresholds[i + 1]
+
+      mu    <- (dnorm(t0) - dnorm(t1)) / (pnorm(t1) - pnorm(t0))
+      z.mid <- qnorm((pnorm(t0) + pnorm(t1)) / 2)
+
+      y[x == level] <- mu
+    }
+
+    if (mean.structure) offset <- mean(as.integer(as.factor(x)), na.rm = TRUE)
+    else                offset <- 0
+
+    y + offset
+  }
+
+  ordered.vars <- unique(thresholds$lhs)
+
+  data.y <- data
+  for (var in ordered.vars)
+    data.y[[var]] <- rescaleVariable(data[[var]], name = var)
+
+  data.y
+}

--- a/R/scale_correction_ordered.R
+++ b/R/scale_correction_ordered.R
@@ -1,53 +1,3 @@
-correctScaleOrdered <- function(model.syntax, data = NULL, ordered = NULL, ...) {
-  cols.ordered <- colnames(data) %in% ordered
-  data[cols.ordered] <- lapply(data[cols.ordered], FUN = as.ordered)
-
-  parTable  <- modsemify(model.syntax)
-  outer     <- parTable[parTable$op == "=~", ]
-  cfa.cat   <- lavaan::cfa(parTableToSyntax(outer), data = data, ...)
-  estimates <- parameterEstimates(cfa.cat)
-
-  thresholds <- estimates[estimates$op == "|", , drop = FALSE]
-
-  if (!NROW(thresholds))
-    return(data)
-
-  rescaleVariable <- function(x, name, mean.structure = TRUE) {
-    thresholds <- c(-Inf, sort(thresholds[thresholds$lhs == name, "est"]), Inf)
-    levels <- levels(x)
-
-    stopif(length(thresholds) != length(levels) + 1,
-           "Unexpected number of thresholds and ordered levels!")
-
-    y <- rep(NA, length(x))
-    for (i in seq_along(levels)) {
-      level <- levels(x)[[i]]
-
-      t0 <- thresholds[i]
-      t1 <- thresholds[i + 1]
-
-      mu    <- (dnorm(t0) - dnorm(t1)) / (pnorm(t1) - pnorm(t0))
-      z.mid <- qnorm((pnorm(t0) + pnorm(t1)) / 2)
-
-      y[x == level] <- z.mid
-    }
-
-    if (mean.structure) offset <- mean(as.integer(as.factor(x)), na.rm = TRUE)
-    else                offset <- 0
-
-    y + offset
-  }
-
-  ordered.vars <- unique(thresholds$lhs)
-
-  data.y <- data
-  for (var in ordered.vars)
-    data.y[[var]] <- rescaleVariable(data[[var]], name = var)
-
-  data.y
-}
-
-
 modsemOrderedScaleCorrection <- function(model.syntax,
                                          data,
                                          method = "lms",
@@ -57,6 +7,10 @@ modsemOrderedScaleCorrection <- function(model.syntax,
                                          N = 1e5, # 100,000
                                          verbose = interactive(),
                                          ...) {
+  message("Scale correcting ordinal variables. ",
+          "This is an experimental feature!\n", 
+          "See `help(modsem_da)` for more information.")
+
   if (is.null(verbose))
     verbose <- TRUE # default
 

--- a/man/TPB_1SO.Rd
+++ b/man/TPB_1SO.Rd
@@ -21,7 +21,7 @@ tpb <- '
 
   # Higher order interaction
   INTxPBC =~ ATT:PBC + SN:PBC + PBC:PBC
-  
+
   # Structural model
   BEH ~ PBC + INT + INTxPBC
 '

--- a/man/TPB_2SO.Rd
+++ b/man/TPB_2SO.Rd
@@ -24,7 +24,7 @@ tpb <- '
 
   # Higher order interaction
   INTxPBC =~ ATT:PC + ATT:PB + SN:PC + SN:PB
-  
+
   # Structural model
   BEH ~ PBC + INT + INTxPBC
 '

--- a/man/bootstrap_modsem.Rd
+++ b/man/bootstrap_modsem.Rd
@@ -41,8 +41,8 @@ bootstrap_modsem(model = modsem, FUN, ...)
 a fitted model.  The function must accept a single argument, the model
 object, and should ideally return a numeric vector; see Value.}
 
-\item{...}{Additional arguments forwarded to \code{lavaan::bootstrapLavaan} 
-for \code{\link{modsem_pi}} objects, or \code{\link{modsem_da}} for 
+\item{...}{Additional arguments forwarded to \code{lavaan::bootstrapLavaan}
+for \code{\link{modsem_pi}} objects, or \code{\link{modsem_da}} for
 \code{\link{modsem_da}} objects.}
 
 \item{R}{number of bootstrap replicates.}
@@ -88,10 +88,10 @@ The function internally resamples the observed data (non-parametric
   feeds the sample to \code{\link{modsem_da}}, evaluates \code{FUN} on the
   refitted object and finally collates the results.
 
-This is a more general version of \code{boostrap_modsem} for 
-  bootstrapping \code{modsem} functions, not modsem objects. 
+This is a more general version of \code{boostrap_modsem} for
+  bootstrapping \code{modsem} functions, not modsem objects.
   \code{model} is now a function to be boostrapped, and \code{...}
-  are now passed to the function (\code{model}), not \code{FUN}. To 
+  are now passed to the function (\code{model}), not \code{FUN}. To
   pass arguments to \code{FUN} use \code{FUN.args}.
 }
 \section{Methods (by class)}{
@@ -146,11 +146,11 @@ tpb <- "
 "
 
 \dontrun{
-boot <- bootstrap_modsem(model = modsem, 
+boot <- bootstrap_modsem(model = modsem,
                          model.syntax = tpb, data = TPB,
-                         method = "dblcent", rcs = TRUE, 
+                         method = "dblcent", rcs = TRUE,
                          rcs.scale.corrected = TRUE,
-                         FUN = "coef", R = 50L) 
+                         FUN = "coef", R = 50L)
 coef <- apply(boot, MARGIN = 2, FUN = mean, na.rm = TRUE)
 se   <- apply(boot, MARGIN = 2, FUN = sd, na.rm = TRUE)
 

--- a/man/centered_estimates.Rd
+++ b/man/centered_estimates.Rd
@@ -44,7 +44,7 @@ A \code{data.frame} with centered estimates in the \code{est} column.
 \description{
 Computes centered estimates of model parameters. This is relevant when there is an
  interaction term in the model, as the simple main effects depend upon the mean structure
- of the structural model. Currenlty only available for 
+ of the structural model. Currenlty only available for
  \code{\link{modsem_da}} and \code{lavaan} object.
  It is not relevant for the PI approaches (excluding the "pind" method, which is not recommended),
  since the indicators are centered before computing the product terms.

--- a/man/colorize_output.Rd
+++ b/man/colorize_output.Rd
@@ -37,7 +37,7 @@ colorize_output(
 
 \item{string}{color of quoted strings.}
 
-\item{split}{Should output be splitted? If \code{TRUE} the output is printed 
+\item{split}{Should output be splitted? If \code{TRUE} the output is printed
 normally (in real time) with no colorization, and the colored output is printed
 after the code has finished executing.}
 
@@ -50,10 +50,10 @@ Invisibly returns the *plain* captured text.
 Capture, colorise, and emit console text
 }
 \examples{
-set_modsem_colors(positive = "red3", 
+set_modsem_colors(positive = "red3",
                   negative = "red3",
-                  true = "darkgreen", 
-                  false = "red3", 
+                  true = "darkgreen",
+                  false = "red3",
                   na = "purple",
                   string = "darkgreen")
 
@@ -78,8 +78,8 @@ colorize_output(split = TRUE, {
 
   est_lms <- modsem(m1, data = oneInt, method = "lms")
   summary(est_lms)
-}) 
-                
+})
+
 colorize_output(modsem_inspect(est_lms))
 }
 }

--- a/man/compare_fit.Rd
+++ b/man/compare_fit.Rd
@@ -13,13 +13,13 @@ alternative hypothesis model (with interaction terms).}
 \item{est_h0}{object of class \code{\link{modsem_da}} or \code{\link{modsem_pi}} representing the
 null hypothesis model (without interaction terms).}
 
-\item{...}{additional arguments passed to the underlying comparison function. E.g., 
+\item{...}{additional arguments passed to the underlying comparison function. E.g.,
 for \code{modsem_pi} models, this can be used to pass arguments to \code{lavaan::lavTestLRT}.
 currently only used for \code{modsem_pi} models.}
 }
 \description{
 Compare the fit of two models using the likelihood ratio test (LRT).
-\code{est_h0} is the null hypothesis model, and \code{est_h1} the alternative hypothesis model. 
+\code{est_h0} is the null hypothesis model, and \code{est_h1} the alternative hypothesis model.
 Importantly, the function assumes that \code{est_h0} does not have more free parameters
 (i.e., degrees of freedom) than \code{est_h1} (the alternative hypothesis model).
 }

--- a/man/estimate_h0.Rd
+++ b/man/estimate_h0.Rd
@@ -20,10 +20,10 @@ estimate_h0(object, warn_no_interaction = TRUE, ...)
 \item{...}{Additional arguments passed to the `modsem_da` function, overriding
 the arguments in the original model.}
 
-\item{reduced}{Should the baseline model be a reduced version of the model? 
+\item{reduced}{Should the baseline model be a reduced version of the model?
 If \code{TRUE}, the latent product term and its (product) indicators are kept in the model,
 but the interaction coefficients are constrained to zero. If \code{FALSE}, the
-interaction terms are removed completely from the model. Note that the models will no longer be 
+interaction terms are removed completely from the model. Note that the models will no longer be
 nested, if the interaction terms are removed from the model completely.}
 }
 \description{

--- a/man/modsem_da.Rd
+++ b/man/modsem_da.Rd
@@ -40,6 +40,7 @@ modsem_da(
   n.threads = NULL,
   algorithm = NULL,
   em.control = NULL,
+  ordered = NULL,
   rcs = FALSE,
   rcs.choose = NULL,
   rcs.scale.corrected = TRUE,
@@ -71,20 +72,20 @@ increased number gives better estimates but slower computation. How many are nee
 For simple models, somewhere between 16-24 nodes should be enough; for more complex models, higher numbers may be needed.
 For models where there is an interaction effect between an endogenous and exogenous variable,
 the number of nodes should be at least 32, but practically (e.g., ordinal/skewed data), more than 32 is recommended. In cases
-where data is non-normal, it might be better to use the \code{qml} approach instead. 
+where data is non-normal, it might be better to use the \code{qml} approach instead.
 You can also consider setting \code{adaptive.quad = TRUE}.}
 
 \item{impute.na}{Should missing values be imputed? If \code{FALSE} missing values
 are removed case-wise. If \code{TRUE} values are imputed using \code{Amelia::amelia}.
-Default is \code{FALSE}. If you want more fine-grained control over how the missing data 
+Default is \code{FALSE}. If you want more fine-grained control over how the missing data
 is imputed, you should consider imputing it yourself.}
 
-\item{convergence.abs}{Absolute convergence criterion. 
+\item{convergence.abs}{Absolute convergence criterion.
 Lower values give better estimates but slower computation. Not relevant when
 using the QML approach. For the LMS approach the EM-algorithm stops whenever
 the relative or absolute convergence criterion is reached.}
 
-\item{convergence.rel}{Relative convergence criterion. 
+\item{convergence.rel}{Relative convergence criterion.
 Lower values give better estimates but slower computation.
 For the LMS approach the EM-algorithm stops whenever
 the relative or absolute convergence criterion is reached.}
@@ -127,7 +128,7 @@ this will be extremely slow but should be more similar to \code{mplus}.}
 
 \item{FIM}{should the Fisher information matrix be calculated using the observed or expected values? Must be either \code{"observed"} or \code{"expected"}.}
 
-\item{EFIM.S}{if the expected Fisher information matrix is computed, \code{EFIM.S} selects the number of Monte Carlo samples. Defaults to 100. 
+\item{EFIM.S}{if the expected Fisher information matrix is computed, \code{EFIM.S} selects the number of Monte Carlo samples. Defaults to 100.
 \strong{NOTE}: This number should likely be increased for better estimates (e.g., 1000), but it might drasticly increase computation time.}
 
 \item{OFIM.hessian}{Logical. If \code{TRUE} (default), standard errors are
@@ -136,15 +137,15 @@ this will be extremely slow but should be more similar to \code{mplus}.}
   of individual score vectors (OPG). For correctly specified models,
   these two matrices are asymptotically equivalent; yielding nearly identical
   standard errors in large samples. The Hessian usually shows smaller finite-sample
-  variance (i.e., it's more consistent), and is therefore the default. 
+  variance (i.e., it's more consistent), and is therefore the default.
 
   Note, that the Hessian is not always positive definite, and is more computationally
-  expensive to calculate. The OPG should always be positive definite, and a lot 
+  expensive to calculate. The OPG should always be positive definite, and a lot
   faster to compute. If the model is correctly specified, and the sample size is large,
-  then the two should yield similar results, and switching to the OPG can save a 
+  then the two should yield similar results, and switching to the OPG can save a
   lot of time. Note, that the required sample size depends on the complexity of the model.
 
-  A large difference between Hessian and OPG suggests misspecification, and 
+  A large difference between Hessian and OPG suggests misspecification, and
   \code{robust.se = TRUE} should be set to obtain sandwich (robust) standard errors.}
 
 \item{EFIM.parametric}{should data for calculating the expected Fisher information matrix be
@@ -165,17 +166,17 @@ fischer information matrix.}
 
 \item{epsilon}{finite difference for numerical derivatives.}
 
-\item{quad.range}{range in z-scores to perform numerical integration in LMS using, 
+\item{quad.range}{range in z-scores to perform numerical integration in LMS using,
 when using quasi-adaptive Gaussian-Hermite Quadratures. By default \code{Inf}, such that \code{f(t)} is integrated from -Inf to Inf,
 but this will likely be inefficient and pointless at a large number of nodes. Nodes outside
 \code{+/- quad.range} will be ignored.}
 
 \item{adaptive.quad}{should a quasi adaptive quadrature be used? If \code{TRUE}, the quadrature nodes will be adapted to the data.
-If \code{FALSE}, the quadrature nodes will be fixed. Default is \code{FALSE}. The adaptive quadrature does not fit an adaptive 
-quadrature to each participant, but instead tries to place more nodes where posterior distribution is highest. Compared with a 
+If \code{FALSE}, the quadrature nodes will be fixed. Default is \code{FALSE}. The adaptive quadrature does not fit an adaptive
+quadrature to each participant, but instead tries to place more nodes where posterior distribution is highest. Compared with a
 fixed Gauss Hermite quadrature this usually means that less nodes are placed at the tails of the distribution.}
 
-\item{adaptive.frequency}{How often should the quasi-adaptive quadrature be calculated? Defaults to 3, meaning 
+\item{adaptive.frequency}{How often should the quasi-adaptive quadrature be calculated? Defaults to 3, meaning
 that it is recalculated every third EM-iteration.}
 
 \item{adaptive.quad.tol}{Relative error tolerance for quasi adaptive quadrature. Defaults to \code{1e-12}.}
@@ -185,12 +186,15 @@ If an integer is specified, it will use that number of threads (e.g., \code{n.th
 If \code{"default"}, it will use the default number of threads (2).
 If \code{"max"}, it will use all available threads, \code{"min"} will use 1 thread.}
 
-\item{algorithm}{algorithm to use for the EM algorithm. Can be either \code{"EM"} or \code{"EMA"}. 
+\item{algorithm}{algorithm to use for the EM algorithm. Can be either \code{"EM"} or \code{"EMA"}.
 \code{"EM"} is the standard EM algorithm. \code{"EMA"} is an
 accelerated EM procedure that uses Quasi-Newton and Fisher Scoring
 optimization steps when needed. Default is \code{"EM"}.}
 
 \item{em.control}{a list of control parameters for the EM algorithm. See \code{\link{default_settings_da}} for defaults.}
+
+\item{ordered}{Variables to be treated as ordered. Ordered (ordinal) variables are scale-corrected to adjust for 
+unequal intervals before model estimation, using an ordered CFA.}
 
 \item{rcs}{Should latent variable indicators be replaced with reliability-corrected
 single item indicators instead? See \code{\link{relcorr_single_item}}.}
@@ -203,35 +207,35 @@ as the \code{choose} argument.}
 reliability-corrected single items are corrected for differences in factor loadings between
 the items. Default is \code{TRUE}.}
 
-\item{orthogonal.x}{If \code{TRUE}, all covariances among exogenous latent variables only are set to zero. 
+\item{orthogonal.x}{If \code{TRUE}, all covariances among exogenous latent variables only are set to zero.
 Default is \code{FALSE}.}
 
-\item{orthogonal.y}{If \code{TRUE}, all covariances among endogenous latent variables only are set to zero. 
-If \code{FALSE} residual covariances are added between pure endogenous variables; 
+\item{orthogonal.y}{If \code{TRUE}, all covariances among endogenous latent variables only are set to zero.
+If \code{FALSE} residual covariances are added between pure endogenous variables;
 those that are predicted by no other endogenous variable in the structural model.
 Default is \code{FALSE}.}
 
-\item{auto.fix.first}{If \code{TRUE} the factor loading of the first indicator, for 
+\item{auto.fix.first}{If \code{TRUE} the factor loading of the first indicator, for
 a given latent variable is fixed to \code{1}. If \code{FALSE} no loadings are fixed
 (automatically). Note that that this might make it such that the model no longer is
-identified. Default is \code{TRUE}. \strong{NOTE} this behaviour is overridden 
+identified. Default is \code{TRUE}. \strong{NOTE} this behaviour is overridden
 if the first loading is labelled, where it gets treated as a free parameter instead. This
 differs from the default behaviour in \code{lavaan}.}
 
-\item{auto.fix.single}{If \code{TRUE}, the residual variance of 
+\item{auto.fix.single}{If \code{TRUE}, the residual variance of
 an observed indicator is set to zero if it is the only indicator of a latent variable.
 If \code{FALSE} the residual variance is not fixed to zero, and treated as a free parameter
-of the model. Default is \code{TRUE}. \strong{NOTE} this behaviour is overridden 
+of the model. Default is \code{TRUE}. \strong{NOTE} this behaviour is overridden
 if the first loading is labelled, where it gets treated as a free parameter instead.}
 
-\item{auto.split.syntax}{Should the model syntax automatically be split into a 
-linear and non-linear part? This is done by moving the structural model for 
+\item{auto.split.syntax}{Should the model syntax automatically be split into a
+linear and non-linear part? This is done by moving the structural model for
 linear endogenous variables (used in interaction terms) into the \code{cov.syntax}
 argument. This can potentially allow interactions between two endogenous variables
-given that both are linear (i.e., not affected by interaction terms). This is 
+given that both are linear (i.e., not affected by interaction terms). This is
 \code{FALSE} by default for the LMS approach.
-When using the QML approach interation effects between exogenous and endogenous 
-variables can in some cases be biased, if the model is not split beforehand. 
+When using the QML approach interation effects between exogenous and endogenous
+variables can in some cases be biased, if the model is not split beforehand.
 The default is therefore \code{TRUE} for the QML approach.}
 
 \item{...}{additional arguments to be passed to the estimation function.}

--- a/man/modsem_da.Rd
+++ b/man/modsem_da.Rd
@@ -195,7 +195,10 @@ optimization steps when needed. Default is \code{"EM"}.}
 \item{em.control}{a list of control parameters for the EM algorithm. See \code{\link{default_settings_da}} for defaults.}
 
 \item{ordered}{Variables to be treated as ordered. Ordered (ordinal) variables are scale-corrected to adjust for 
-unequal intervals before model estimation, using an ordered CFA.}
+unequal intervals before model estimation, by estimating the distributions of the underlying continuous response variables. 
+The distributions of the response variables are estimated using a combination of bootstrapping and Monte Carlo simulations.
+For small differences in the spacing of the intervals, the point estimates should be unbiased. The standard errors may be
+underestimated though. Using robust standard errors may make the estimates of the standard errors more accurate.}
 
 \item{ordered.boot}{Number of bootstraps used to estimate the underlying continuous distribution of the
 ordinal variables.}

--- a/man/modsem_da.Rd
+++ b/man/modsem_da.Rd
@@ -41,6 +41,7 @@ modsem_da(
   algorithm = NULL,
   em.control = NULL,
   ordered = NULL,
+  ordered.boot = 5,
   rcs = FALSE,
   rcs.choose = NULL,
   rcs.scale.corrected = TRUE,
@@ -195,6 +196,9 @@ optimization steps when needed. Default is \code{"EM"}.}
 
 \item{ordered}{Variables to be treated as ordered. Ordered (ordinal) variables are scale-corrected to adjust for 
 unequal intervals before model estimation, using an ordered CFA.}
+
+\item{ordered.boot}{Number of bootstraps used to estimate the underlying continuous distribution of the
+ordinal variables.}
 
 \item{rcs}{Should latent variable indicators be replaced with reliability-corrected
 single item indicators instead? See \code{\link{relcorr_single_item}}.}

--- a/man/modsem_inspect.Rd
+++ b/man/modsem_inspect.Rd
@@ -38,24 +38,24 @@ measures from a \code{\link{modsem_da}} object.
 }
 \details{
 For \code{\link{modsem_pi}} objects, it is just a wrapper for \code{lavaan::lavInspect}.
- For \code{\link{modsem_da}} objects an internal function is called, which takes different 
+ For \code{\link{modsem_da}} objects an internal function is called, which takes different
  keywords for the \code{what} argument.
 
 Below is a list of possible values for the \code{what} argument,
 organised in several sections.  Keywords are \emph{case-sensitive}.
 
-\strong{Presets} 
+\strong{Presets}
 
 \describe{
   \item{\code{"default"}}{Everything in \emph{Sample information}, \emph{Optimiser diagnostics}
-  \emph{Parameter tables}, \emph{Model matrices}, and \emph{Expected-moment matrices} except  
+  \emph{Parameter tables}, \emph{Model matrices}, and \emph{Expected-moment matrices} except
   the raw \code{data} slot}
-  \item{\code{"coef"}}{Coefficients and variance-covariance matrix of both free and constrained parameters (same as \code{"coef.all"}).}  
-  \item{\code{"coef.all"}}{Coefficients and variance-covariance matrix of both free and constrained parameters (same as \code{"coef"}).}  
-  \item{\code{"coef.free"}}{Coefficients and variance-covariance matrix of the free parameters.}  
-  \item{\code{"all"}}{All items listed below, including \code{data}.}  
-  \item{\code{"matrices"}}{The model matrices.}  
-  \item{\code{"optim"}}{Only the items under \emph{Optimiser diagnostics}}.  
+  \item{\code{"coef"}}{Coefficients and variance-covariance matrix of both free and constrained parameters (same as \code{"coef.all"}).}
+  \item{\code{"coef.all"}}{Coefficients and variance-covariance matrix of both free and constrained parameters (same as \code{"coef"}).}
+  \item{\code{"coef.free"}}{Coefficients and variance-covariance matrix of the free parameters.}
+  \item{\code{"all"}}{All items listed below, including \code{data}.}
+  \item{\code{"matrices"}}{The model matrices.}
+  \item{\code{"optim"}}{Only the items under \emph{Optimiser diagnostics}}.
   \item{\code{"fit"}}{A list with \code{fit.h0}, \code{fit.h1}, comparative.fit}
 }
 
@@ -74,7 +74,7 @@ organised in several sections.  Keywords are \emph{case-sensitive}.
   \item{\code{"vcov.all"}}{Variance–covariance of both free and constrained coefficients.}
 }
 
-\strong{Optimiser diagnostics:}  
+\strong{Optimiser diagnostics:}
 
 \describe{
   \item{\code{"coefficients.free"}}{Free parameter values.}
@@ -85,7 +85,7 @@ organised in several sections.  Keywords are \emph{case-sensitive}.
   \item{\code{"convergence"}}{\code{TRUE}/\code{FALSE} indicating whether the model converged.}
 }
 
-\strong{Parameter tables:}  
+\strong{Parameter tables:}
 
 \describe{
   \item{\code{"partable"}}{Parameter table with estimated parameters.}
@@ -107,13 +107,13 @@ organised in several sections.  Keywords are \emph{case-sensitive}.
   \item{\code{"alpha"}}{\eqn{\alpha} – Intercepts for endogenous variables}
   \item{\code{"beta0"}}{\eqn{\beta_0} – Intercepts for exogenous variables}
 }
-\strong{Model-implied matrices:}  
+\strong{Model-implied matrices:}
 
 \describe{
-  \item{\code{"cov.ov"}}{Model-implied covariance of observed variables.} 
+  \item{\code{"cov.ov"}}{Model-implied covariance of observed variables.}
   \item{\code{"cov.lv"}}{Model-implied covariance of latent variables.}
   \item{\code{"cov.all"}}{Joint covariance of observed + latent variables.}
-  \item{\code{"cor.ov"}}{Correlation counterpart of \code{"cov.ov"}.} 
+  \item{\code{"cor.ov"}}{Correlation counterpart of \code{"cov.ov"}.}
   \item{\code{"cor.lv"}}{Correlation counterpart of \code{"cov.lv"}.}
   \item{\code{"cor.all"}}{Correlation counterpart of \code{"cov.all"}.}
   \item{\code{"mean.ov"}}{Expected means of observed variables.}
@@ -132,13 +132,13 @@ organised in several sections.  Keywords are \emph{case-sensitive}.
   \item{\code{"res.ov"}}{Standardized residuals (i.e., \code{1 - R^2}) for observed variables (i.e., indicators).}
 }
 
-\strong{Interaction-specific caveats:}  
+\strong{Interaction-specific caveats:}
 
 \itemize{
   \item If the model contains an \emph{uncentred} latent interaction term it is centred
     internally before any \code{cov.*}, \code{cor.*}, or \code{mean.*} matrices are
-    calculated.  
-  \item These matrices should not be used to compute fit-statistics (e.g., 
+    calculated.
+  \item These matrices should not be used to compute fit-statistics (e.g.,
     chi-square and RMSEA) if there is an interaction term in the model.
 }
 }

--- a/man/modsem_mimpute.Rd
+++ b/man/modsem_mimpute.Rd
@@ -47,7 +47,7 @@ but can also be (a lot) slower.}
 Estimate a \code{modsem} model using multiple imputation
 }
 \details{
-\code{modsem_impute} is currently only available for the DA approaches 
+\code{modsem_impute} is currently only available for the DA approaches
  (LMS and QML). It performs multiple imputation using \code{Amelia::amelia}
  and returns aggregated coefficients from the multiple imputations, along with
  corrected standard errors.

--- a/man/modsem_mplus.Rd
+++ b/man/modsem_mplus.Rd
@@ -61,7 +61,7 @@ m1 <- '
 # Outer Model
   X =~ x1 + x2
   Z =~ z1 + z2
-  Y =~ y1 + y2 
+  Y =~ y1 + y2
 
 # Inner model
   Y ~ X + Z + X:Z

--- a/man/modsem_pi.Rd
+++ b/man/modsem_pi.Rd
@@ -56,7 +56,7 @@ modsem_pi(
 
 \item{match}{should the product indicators be created by using the match-strategy}
 
-\item{match.recycle}{should the indicators be recycled when using the match-strategy? I.e., 
+\item{match.recycle}{should the indicators be recycled when using the match-strategy? I.e.,
 if one of the latent variables have fewer indicators than the other, some indicators
 are recycled to match the latent variable with the most indicators.}
 
@@ -64,7 +64,7 @@ are recycled to match the latent variable with the most indicators.}
 
 \item{center.data}{should data be centered before fitting model}
 
-\item{first.loading.fixed}{Should the first factor loading in the latent product be fixed to one? Defaults to \code{FALSE}, as 
+\item{first.loading.fixed}{Should the first factor loading in the latent product be fixed to one? Defaults to \code{FALSE}, as
 this already happens in \code{lavaan} by default. If \code{TRUE}, the first factor loading in the latent product is fixed to one.
 Manually in the generated syntax (e.g., \code{XZ =~ 1*x1z1}).'}
 
@@ -89,17 +89,17 @@ Manually in the generated syntax (e.g., \code{XZ =~ 1*x1z1}).'}
   \item{"equality"}{Residuals of product indicators with variables in common are constrained to have equal covariances".
                     Can be useful for models where the model is unidentifiable using \code{res.cov.method == "simple"},
                     (e.g., when there is an interaction between an observed and a latent variable).}
-  \item{"none"}{Residual covariances between product indicators are not specificed (i.e., constrained to zero). 
+  \item{"none"}{Residual covariances between product indicators are not specificed (i.e., constrained to zero).
                 Produces the same results as \code{constrained.cov.syntax = FALSE}.
                 Can be useful for models where the model is unidentifiable using \code{res.cov.method == "simple"},
                 (e.g., when there is an interaction between an observed and a latent variable).}
 }}
 
 \item{res.cov.across}{Should residual covariances be specified/freed across different interaction terms.
-For example if you have two interaction terms \code{X:Z} and \code{X:W} the residuals of the 
-generated product indicators \code{x1:z1} and \code{x1:w1} may be correlated. If \code{TRUE} 
-residual covariances are allowed across different latent interaction terms. If \code{FALSE} 
-residual covariances are only allowed between product indicators which belong to the same 
+For example if you have two interaction terms \code{X:Z} and \code{X:W} the residuals of the
+generated product indicators \code{x1:z1} and \code{x1:w1} may be correlated. If \code{TRUE}
+residual covariances are allowed across different latent interaction terms. If \code{FALSE}
+residual covariances are only allowed between product indicators which belong to the same
 latent interaction term.}
 
 \item{auto.scale}{methods which should be scaled automatically (usually not useful)}
@@ -132,7 +132,7 @@ as the \code{choose} argument.}
 created from the reliability-corrected single items (created if \code{rcs = TRUE})
 be specified and constrained before estimating the model? If \code{TRUE} the estimates
 for the constraints are approximated using a monte carlo simulation (see the \code{rcs.mc.reps} argument).
-If \code{FALSE} the residual variances are not specified, which usually mean that all 
+If \code{FALSE} the residual variances are not specified, which usually mean that all
 are constrained to zero.}
 
 \item{rcs.mc.reps}{Sample size used in monte-carlo simulation, when approximating the

--- a/man/modsem_predict.Rd
+++ b/man/modsem_predict.Rd
@@ -36,7 +36,7 @@ If \code{FALSE}, use the model specified in \code{object}. Using \code{H0 = FALS
 \item{center.data}{Should data be centered before computing factor scores? Default is \code{TRUE}.}
 }
 \value{
-* For \code{\link{modsem_pi}}: whatever \code{lavaan::predict()}, which usually 
+* For \code{\link{modsem_pi}}: whatever \code{lavaan::predict()}, which usually
   returns a matrix of factor scores.
 * For \code{\link{modsem_da}}: a numeric matrix \eqn{n \times p}, where \eqn{n} is the number of
   (complete) observations in the dataset, and \eqn{p} the number of latent variables. Each
@@ -52,7 +52,7 @@ values or factor scores from \code{\link{modsem}} models.
 \item \code{modsem_predict(modsem_da)}: Computes (optionally standardised) factor scores via the
 regression method using the baseline model unless \code{H0 = FALSE}.
 
-\item \code{modsem_predict(modsem_pi)}: 
+\item \code{modsem_predict(modsem_pi)}: Wrapper for \code{lavaan::predict}
 
 }}
 \examples{

--- a/man/plot_interaction.Rd
+++ b/man/plot_interaction.Rd
@@ -45,7 +45,7 @@ separate regression lines. Each distinct value in \code{vals_z} defines a separa
 group (plotted with a different color). If \code{rescale=TRUE}, these values
 are also assumed to be in standardized units.}
 
-\item{model}{An object of class \code{\link{modsem_pi}}, \code{\link{modsem_da}}, 
+\item{model}{An object of class \code{\link{modsem_pi}}, \code{\link{modsem_da}},
 \code{\link{modsem_mplus}}, or possibly a \code{lavaan} object. Must be a fitted
 SEM model containing paths for \code{y ~ x + z + x:z}.}
 

--- a/man/plot_jn.Rd
+++ b/man/plot_jn.Rd
@@ -41,7 +41,7 @@ plot_jn(
 
 \item{detail}{The number of generated data points to use for the plot (default is 1000). You can increase this value for smoother plots.}
 
-\item{sd.line}{A thick black line showing \code{+/- sd.line * sd(z)}. NOTE: This line will be truncated by \code{min_z} and \code{max_z} if 
+\item{sd.line}{A thick black line showing \code{+/- sd.line * sd(z)}. NOTE: This line will be truncated by \code{min_z} and \code{max_z} if
 the sd.line falls outside of \code{[min_z, max_z]}.}
 
 \item{standardized}{Should coefficients be standardized beforehand?}
@@ -72,8 +72,8 @@ The plot displays:
 \dontrun{
 library(modsem)
 
-m1 <-  ' 
-  visual  =~ x1 + x2 + x3 
+m1 <-  '
+  visual  =~ x1 + x2 + x3
   textual =~ x4 + x5 + x6
   speed   =~ x7 + x8 + x9
 

--- a/man/set_modsem_colors.Rd
+++ b/man/set_modsem_colors.Rd
@@ -43,10 +43,10 @@ All arguments are optional; omitted ones fall back to the defaults below.
 Pass \code{active = FALSE} to turn highlighting off (and reset the palette).
 }
 \examples{
-set_modsem_colors(positive = "red3", 
+set_modsem_colors(positive = "red3",
                   negative = "red3",
-                  true = "darkgreen", 
-                  false = "red3", 
+                  true = "darkgreen",
+                  false = "red3",
                   na = "purple",
                   string = "darkgreen")
 
@@ -71,8 +71,8 @@ colorize_output(split = TRUE, {
 
   est_lms <- modsem(m1, data = oneInt, method = "lms")
   summary(est_lms)
-}) 
-                
+})
+
 colorize_output(modsem_inspect(est_lms))
 }
 }

--- a/man/simple_slopes.Rd
+++ b/man/simple_slopes.Rd
@@ -96,29 +96,29 @@ hypothesis testing. This is useful for visualizing and interpreting moderation
 effects or to see how the slope changes at different values of the moderator.
 }
 \details{
-\strong{Computation Steps}  
+\strong{Computation Steps}
 \enumerate{
    \item The function extracts parameter estimates (and, if necessary, their covariance
-         matrix) from the fitted SEM model (\code{model}).  
+         matrix) from the fitted SEM model (\code{model}).
    \item It identifies the coefficients for \code{x}, \code{z}, and \code{x:z} in the model's
          parameter table, as well as the variance of \code{x}, \code{z} and the residual variance
          of \code{y}.
    \item If \code{xz} is not provided, it will be constructed by combining \code{x} and
-         \code{z} with a colon (\code{":"}). Depending on the approach used to estimate the model, 
-         the colon may be removed or replaced internally; the function attempts to reconcile that.  
+         \code{z} with a colon (\code{":"}). Depending on the approach used to estimate the model,
+         the colon may be removed or replaced internally; the function attempts to reconcile that.
 
   \item A grid of \code{x} and \code{z} values is created from \code{vals_x} and
         \code{vals_z}. If \code{rescale = TRUE}, these values are transformed back into raw
-        metric units for display in the output.  
+        metric units for display in the output.
   \item For each point in the grid, a predicted value of \code{y} is computed via
         \code{(beta0 + beta_x * x + beta_z * z + beta_xz * x * z)} and, if included, a
-        mean offset.  
+        mean offset.
   \item The standard error (\code{std.error}) is derived from the covariance matrix of
         the relevant parameters, and if \code{ci_type = "prediction"}, adds the residual
-        variance.  
+        variance.
   \item Confidence (or prediction) intervals are formed using \code{ci_width} (defaulting
         to 95\%). The result is a table-like data frame with predicted values, CIs,
-        standard errors, z-values, and p-values.  
+        standard errors, z-values, and p-values.
 }
 }
 \examples{

--- a/man/standardize_model.Rd
+++ b/man/standardize_model.Rd
@@ -21,7 +21,7 @@ Ignored if \code{monte.carlo = FALSE}.}
 \item{...}{Arguments passed on to other functions}
 }
 \value{
-The same object (returned invisibly) with three slots overwritten  
+The same object (returned invisibly) with three slots overwritten
 \describe{
   \item{\code{$parTable}}{Parameter table whose columns \code{est} and \code{std.error}
         now hold standardized estimates and their (delta-method)
@@ -31,7 +31,7 @@ The same object (returned invisibly) with three slots overwritten
         variable has mean 0 by definition.}
   \item{\code{$vcov}}{Variance–covariance matrix corresponding to the updated
         coefficient vector.  Rows/columns for intercepts are dropped, and
-        the sub-matrix associated with rescaled parameters is adjusted 
+        the sub-matrix associated with rescaled parameters is adjusted
         so that its diagonal equals the squared standardized standard errors.}
 }
 The object keeps its class attributes, allowing seamless use by downstream
@@ -63,7 +63,7 @@ sfit <- standardize_model(fit, monte.carlo = TRUE)
 
 # Compare unstandardized vs. standardized summaries
 summary(fit)  # unstandardized
-summary(sfit) # standardized 
+summary(sfit) # standardized
 }
 
 }

--- a/man/standardized_estimates.Rd
+++ b/man/standardized_estimates.Rd
@@ -27,7 +27,7 @@ standardized_estimates(object, ...)
   ...
 )
 
-\method{standardized_estimates}{modsem_mplus}(object, type = "stdyx", ...)
+\method{standardized_estimates}{modsem_mplus}(object, type = "stdyx", mc.reps = 1e+06, ...)
 
 \method{standardized_estimates}{modsem_pi}(
   object,
@@ -51,20 +51,20 @@ standard errors; if \code{FALSE}, use the delta method (default).}
 
 \item{tolerance.zero}{Threshold below which standard errors are set to \code{NA}.}
 
-\item{type}{Type of standardized estimates to retrieve. Can be one of: \code{"stdyx", "stdy", "std", "un"}.}
+\item{type}{Type of standardized estimates to retrieve. Can be one of: \code{"stdyx", "stdy", "std", "un", "modsem"}.}
 
 \item{correction}{Logical. Whether to apply a correction to the standardized estimates
 of the interaction term. By default, \code{FALSE}, which standardizes the interaction term
 such that \eqn{\sigma^2(XZ) = 1}, consistent with \code{lavaan}'s treatment of latent interactions.
 This is usually wrong, as it does not account for the fact that the interaction term
 is a product of two variables, which means that the variance of the interaction term
-of standardized variables (usually) is not equal to 1. 
+of standardized variables (usually) is not equal to 1.
 
-Hence the scale of the interaction effect changes, such that 
-the standardized interaction term does not correspond to one (standardized) unit 
-change in the moderating variables. If \code{TRUE}, a correction is applied by 
-computing the interaction term \eqn{b_3 = \frac{B_3 \sigma(X) \sigma(Z)}{\sigma(Y)}} (where 
-\eqn{B_3} is the unstandardized coefficient for the interaction term), and solving for \eqn{\sigma(XZ)}, which 
+Hence the scale of the interaction effect changes, such that
+the standardized interaction term does not correspond to one (standardized) unit
+change in the moderating variables. If \code{TRUE}, a correction is applied by
+computing the interaction term \eqn{b_3 = \frac{B_3 \sigma(X) \sigma(Z)}{\sigma(Y)}} (where
+\eqn{B_3} is the unstandardized coefficient for the interaction term), and solving for \eqn{\sigma(XZ)}, which
 is used to correct the variance of the interaction term, and its covariances.}
 
 \item{std.errors}{Character string indicating the method used to compute standard errors
@@ -90,11 +90,11 @@ Computes standardized estimates of model parameters for various types of \code{\
 \details{
 Standard errors can either be calculated using the delta method, or a monte.carlo simulation
   (\code{monte.carlo} is not available for \code{\link{modsem_pi}} objects if \code{correction == FALSE}.).
-  \strong{NOTE} that the standard errors of the standardized paramters change the assumptions of the 
+  \strong{NOTE} that the standard errors of the standardized paramters change the assumptions of the
   model, and will in most cases yield different z and p-values, compared to the unstandardized solution.
   In almost all cases, significance testing should be based on the unstandardized solution. Since,
   the standardization process changes the model assumptions, it also changes what the p-statistics measure.
-  I.e., the test statistics for the standardized and unstandardized solutions belong to different sets of 
+  I.e., the test statistics for the standardized and unstandardized solutions belong to different sets of
   hypothesis, which are not exactly equivalent to each other.
 
 For \code{modsem_da} and \code{modsem_mplus} objects, the interaction term is not a formal

--- a/man/summarize_partable.Rd
+++ b/man/summarize_partable.Rd
@@ -17,7 +17,7 @@ summarize_partable(
 )
 }
 \arguments{
-\item{parTable}{A parameter table, typically obtained from a \code{\link{modsem}} model 
+\item{parTable}{A parameter table, typically obtained from a \code{\link{modsem}} model
 using \code{\link{parameter_estimates}} or \code{\link{standardized_estimates}}.}
 
 \item{scientific}{Logical, whether to print p-values in scientific notation.}

--- a/man/summary.Rd
+++ b/man/summary.Rd
@@ -57,7 +57,7 @@
 \arguments{
 \item{object}{modsem object to summarized}
 
-\item{H0}{Should the baseline model be estimated, and used to produce 
+\item{H0}{Should the baseline model be estimated, and used to produce
 comparative fit?}
 
 \item{verbose}{Should messages be printed?}
@@ -76,10 +76,10 @@ comparative fit?}
 
 \item{centered}{print mean centered estimates}
 
-\item{monte.carlo}{should Monte Carlo bootstrapped standard errors be used? Only 
+\item{monte.carlo}{should Monte Carlo bootstrapped standard errors be used? Only
 relevant if \code{standardized = TRUE}. If \code{FALSE} delta method is used instead.}
 
-\item{mc.reps}{number of Monte Carlo repetitions. Only relevant if \code{monte.carlo = TRUE}, 
+\item{mc.reps}{number of Monte Carlo repetitions. Only relevant if \code{monte.carlo = TRUE},
 and \code{standardized = TRUE}.}
 
 \item{loadings}{print loadings}
@@ -92,7 +92,7 @@ and \code{standardized = TRUE}.}
 
 \item{variances}{print variances}
 
-\item{var.interaction}{if FALSE variances for interaction terms will be removed 
+\item{var.interaction}{if FALSE variances for interaction terms will be removed
 from the output}
 
 \item{...}{arguments passed to lavaan::summary()}


### PR DESCRIPTION
Added an experimental feature for handling ordered/ordinal variables in `modsem_da()`. Simulations shows that it yields unbiased estimates for small-moderate violations of equal intervals when treating ordinal variables as continuous variables.