### PR TITLE
Handle residual covariances between endogenous and exogenous lvs in `modsem_predict()`

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -363,8 +363,8 @@ modsem_nobs <- function(object, ...) {
 #'   by the \code{\link{modsem_da}} method.
 #' @param method Character. Scoring method. One of \code{"EBM"} (Empirical
 #'   Bayes Modal; MAP estimate of the posterior), \code{"ML"} (maximum
-#'   likelihood), \code{"Bartlett"} (alias for \code{"EBM"}), or
-#'   \code{"Regression"} (alias for \code{"ML"}). For \code{\link{modsem_da}}
+#'   likelihood), \code{"Regression"} (alias for \code{"EBM"}), or
+#'   \code{"Bartlett"} (alias for \code{"ML"}). For \code{\link{modsem_da}}
 #'   objects this selects the optimisation-based scoring algorithm. For
 #'   \code{\link{modsem_pi}} objects the argument is forwarded to
 #'   \code{lavaan::lavPredict}, which accepts the same \code{method} values.

--- a/R/model_da.R
+++ b/R/model_da.R
@@ -990,9 +990,3 @@ getFinalModel <- function(model, theta, method, modelSE = NULL) {
 
   finalModel
 }
-
-
-markOV_IntTermsParTable <- function(parTable, model) {
-  model$model$info
-  browser()
-}

--- a/R/predict_da.R
+++ b/R/predict_da.R
@@ -16,8 +16,8 @@ modsem_predict.modsem_da <- function(object,
     several.ok = FALSE
   )
 
-  if      (method == "BARTLETT")   method <- "EBM"
-  else if (method == "REGRESSION") method <- "ML"
+  if      (method == "BARTLETT")   method <- "ML"
+  else if (method == "REGRESSION") method <- "EBM"
 
   predicted <- modsemPredictDA(
     object  = object,

--- a/R/utils_da.R
+++ b/R/utils_da.R
@@ -635,12 +635,6 @@ getCoefMatricesDA_LavRepresentation <- function(parTable,
   indsLV <- getIndsLVs(parTable, lVs = lVs)
   inds <- unique(unlist(indsLV))
 
-  # Create lambda
-  lambda <- getLambdaParTable(
-    parTable = parTable, rows = inds,
-    cols = lVs, fill.missing = TRUE
-  )
-
   createBeta <- function(vars) {
     beta <- matrix(0, nrow = length(vars), ncol = length(vars),
                    dimnames = list(vars, vars))
@@ -657,7 +651,7 @@ getCoefMatricesDA_LavRepresentation <- function(parTable,
       rhs <- betaRows$rhs[i]
       est <- betaRows$est[i]
 
-      beta[lhs, rhs] <- est
+      beta[rhs, lhs] <- est
     }
 
     beta
@@ -697,6 +691,11 @@ getCoefMatricesDA_LavRepresentation <- function(parTable,
 
     tau 
   }
+
+  lambda <- getLambdaParTable(
+    parTable = parTable, rows = inds,
+    cols = lVs, fill.missing = TRUE
+  )
 
   psi   <- createCov(c(xis, etas))
   beta  <- createBeta(c(xis, etas))
@@ -789,7 +788,9 @@ calcExpectedMatricesDA_Group <- function(parTable, xis = NULL, etas = NULL, intT
   theta     <- matricesCentered$theta
   theta.c   <- matricesCentered$theta.c
 
-  sigma.lv <- binv %*% psi %*% t(binv)
+  # sigma.lv <- binv %*% psi %*% t(binv)
+  # We have it the opposite way with the lavaan/lisrel representation of beta/binv
+  sigma.lv <- t(binv) %*% psi %*% binv
   sigma.ov <- (
     (lambda + lambda.c) %*% sigma.lv %*% t(lambda + lambda.c) + theta + theta.c
   )
@@ -825,7 +826,7 @@ calcExpectedMatricesDA_Group <- function(parTable, xis = NULL, etas = NULL, intT
   lambdaNc.c <- matricesNonCentered$lambda.c
   alphaNc    <- matricesNonCentered$alpha
 
-  mu.lv <- binvNc %*% alphaNc
+  mu.lv <- t(binvNc) %*% alphaNc
   mu.ov  <- nuNc + (lambdaNc + lambdaNc.c) %*% mu.lv
   mu.all <- rbind(mu.lv, mu.ov)
 

--- a/man/modsem-package.Rd
+++ b/man/modsem-package.Rd
@@ -18,6 +18,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Kjell Solem Slupphaug \email{slupphaugkjell@gmail.com} (\href{https://orcid.org/0009-0005-8324-2834}{ORCID})
 
+Authors:
+\itemize{
+  \item Kjell Solem Slupphaug \email{slupphaugkjell@gmail.com} (\href{https://orcid.org/0009-0005-8324-2834}{ORCID})
+}
+
 Other contributors:
 \itemize{
   \item Mehmet Mehmetoglu \email{mehmetm@ntnu.no} (\href{https://orcid.org/0000-0002-6092-8551}{ORCID}) [contributor]

--- a/man/modsem_predict.Rd
+++ b/man/modsem_predict.Rd
@@ -38,8 +38,8 @@ by the \code{\link{modsem_da}} method.}
 
 \item{method}{Character. Scoring method. One of \code{"EBM"} (Empirical
 Bayes Modal; MAP estimate of the posterior), \code{"ML"} (maximum
-likelihood), \code{"Bartlett"} (alias for \code{"EBM"}), or
-\code{"Regression"} (alias for \code{"ML"}). For \code{\link{modsem_da}}
+likelihood), \code{"Regression"} (alias for \code{"EBM"}), or
+\code{"Bartlett"} (alias for \code{"ML"}). For \code{\link{modsem_da}}
 objects this selects the optimisation-based scoring algorithm. For
 \code{\link{modsem_pi}} objects the argument is forwarded to
 \code{lavaan::lavPredict}, which accepts the same \code{method} values.}

--- a/src/predict_da.cpp
+++ b/src/predict_da.cpp
@@ -27,6 +27,9 @@ arma::mat diagPartitionedWithCorners(
   const int nz = Z.n_rows;
   const int mz = Z.n_cols;
 
+  if (!nz || !mz) // relevant only for QML
+    return diagPartitioned(X, Y);
+
   if (nz != ny)
     Rcpp::stop("Number of rows in Z must match the number of rows in Y!");
 

--- a/src/predict_da.cpp
+++ b/src/predict_da.cpp
@@ -19,6 +19,27 @@ arma::mat diagPartitioned(const arma::mat X, const arma::mat Y) {
   return Z;
 }
 
+
+arma::mat diagPartitionedWithCorners(
+  const arma::mat X, const arma::mat Y, const arma::mat Z) {
+  const int mx = X.n_cols;
+  const int ny = Y.n_rows;
+  const int nz = Z.n_rows;
+  const int mz = Z.n_cols;
+
+  if (nz != ny)
+    Rcpp::stop("Number of rows in Z must match the number of rows in Y!");
+
+  if (mz != mx)
+    Rcpp::stop("Number of cols in Z must match the number of cols in X!");
+
+  return arma::join_cols(
+    arma::join_rows(X, Z.t()),
+    arma::join_rows(Z, Y)
+  );
+}
+
+
 struct ModelMatrices {
   // Measurement Model
   arma::mat Lambda;
@@ -49,10 +70,11 @@ struct ModelMatrices {
     tau    = arma::join_cols(tauX, tauY);
 
     // Structural Model
-    const arma::mat PhiX = Rcpp::as<arma::mat>(matrices["phi"]);
-    const arma::mat PsiY = Rcpp::as<arma::mat>(matrices["psi"]);
+    const arma::mat PhiX      = Rcpp::as<arma::mat>(matrices["phi"]);
+    const arma::mat PsiY      = Rcpp::as<arma::mat>(matrices["psi"]);
+    const arma::mat CovZetaXi = Rcpp::as<arma::mat>(matrices["covZetaXi"]);
 
-    Psi        = diagPartitioned(PhiX, PsiY);
+    Psi        = diagPartitionedWithCorners(PhiX, PsiY, CovZetaXi);
     GammaXi    = Rcpp::as<arma::mat>(matrices["gammaXi"]);
     GammaEta   = Rcpp::as<arma::mat>(matrices["gammaEta"]);
     OmegaXiXi  = Rcpp::as<arma::mat>(matrices["omegaXiXi"]);

--- a/tests/testthat/test_rescov_eta_xi_lms.R
+++ b/tests/testthat/test_rescov_eta_xi_lms.R
@@ -34,6 +34,14 @@ testthat::test_that("Residual covariances between xis and etas in the LMS approa
   fit.lav <- lavaan::sem(syntax, data, meanstructure = TRUE)
   fit.mod <- modsem(syntax, data, method = "lms", optimize = FALSE, convergence.abs = 1e-6)
 
+  ebm.mod <- c(modsem_predict(fit.mod, method = "EBM"))
+  ebm.lav <- c(lavaan::lavPredict(fit.lav, method = "EBM"))
+  testthat::expect_equal(ebm.mod, ebm.lav, tol = 1e-4)
+
+  ml.mod  <- c(modsem_predict(fit.mod, method = "ML"))
+  ml.lav  <- c(lavaan::lavPredict(fit.lav, method = "ML"))
+  testthat::expect_equal(ml.mod, ml.lav, tol = 1e-4)
+
   est.mod <- c(coef(fit.mod))
   est.lav <- lavaan::coef(fit.lav)[names(est.mod)]
 


### PR DESCRIPTION
Fix for #162, and some smaller fixes.