### PR TITLE
Move MplusAutomation from Imports to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,14 +56,14 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 LinkingTo: Rcpp, RcppArmadillo
-Imports: Rcpp, purrr, stringr, lavaan, rlang, MplusAutomation, nlme, dplyr, 
+Imports: Rcpp, purrr, stringr, lavaan, rlang, nlme, dplyr,
   mvnfast, stats, fastGHQuad, mvtnorm, ggplot2, parallel, plotly, Deriv, MASS, Amelia,
   grDevices, cli, RhpcBLASctl, memoise
 Depends: 
     R (>= 4.1.0)
 URL: https://modsem.org,
   https://github.com/kss2k/modsem
-Suggests: knitr, rmarkdown, ggpubr, RColorBrewer
+Suggests: knitr, rmarkdown, ggpubr, RColorBrewer, MplusAutomation
 VignetteBuilder: knitr
 Config/roxygen2/version: 8.0.0
 RoxygenNote: 7.3.3

--- a/R/modsem_mplus.R
+++ b/R/modsem_mplus.R
@@ -65,6 +65,9 @@ modsem_mplus <- function(model.syntax,
                          output.std = TRUE,
                          categorical = NULL,
                          ...) {
+  if (!requireNamespace("MplusAutomation", quietly = TRUE))
+    stop("modsem_mplus() requires the 'MplusAutomation' package; please install it.")
+
   if (rcs) { # use reliability-correct single items?
     corrected <- relcorr_single_item(
       syntax          = model.syntax,


### PR DESCRIPTION
Hi Kjell,

Small dependency cleanup: this moves `MplusAutomation` from `Imports` to `Suggests`, since it's used only by the optional Mplus interface (`modsem_mplus()` / `modsem(method = "mplus")`). Users who don't use Mplus then don't have to carry the dependency.

**Why this is the correct classification**

Per *Writing R Extensions*:
- §1.1.3 ("Package Dependencies"): namespaces accessed only via `::` "must be listed [in Imports], **or in 'Suggests' or 'Enhances'**," and `Suggests` is for packages "not necessarily needed";
- §1.1.3.1 ("Suggested packages"): the recommended pattern for conditional use is `if (requireNamespace("pkg", quietly = TRUE)) { pkg::fn(...) }`, to keep installations lean.

`MplusAutomation` fits exactly: not imported in `NAMESPACE`, referenced only as `MplusAutomation::` inside the optional `modsem_mplus()` path, which needs separately-installed (commercial) Mplus anyway. This PR adds precisely that `requireNamespace()` guard. (For reference, lavaan offers Mplus interoperability with no dependency on the package.)

**Why it matters in practice (Nix / Apple Silicon)**

`MplusAutomation` transitively pulls `gsubfn -> xvfb -> mesa`. Under Nix on `aarch64-darwin` (Apple Silicon), `mesa` has no cached binary in the usual substituters, so it compiles from source. That is a multi-hour build (it hadn't finished after 2+ hours for me) on *every* environment that includes modsem, even when the Mplus feature is never used. On `x86_64-linux` (e.g. CI) these are all cached, so the cost is invisible there but very real on other platforms. Moving the dependency to `Suggests` drops the entire `gsubfn -> xvfb -> mesa` chain out of the closure.

**Changes**
- `DESCRIPTION`: move `MplusAutomation` from `Imports` to `Suggests`.
- `R/modsem_mplus.R`: add a `requireNamespace("MplusAutomation")` guard at the top of `modsem_mplus()` with a clear message.

**Already CRAN-clean, no further guards needed.** All uses are conditional, so it passes `R CMD check` even with Suggests not installed (`_R_CHECK_DEPENDS_ONLY_`):
- not imported in `NAMESPACE`, so the package loads without it;
- the `modsem_mplus.R` examples are in `\dontrun{}`;
- `tests/testthat/test_mplus.R` and `test_higher_order_da.R` already wrap detection in `tryCatch(MplusAutomation::detectMplus(), error = \(e) FALSE)`, so they skip cleanly when it's absent;
- the only vignette call to `method = "mplus"` (in `methods.Rmd`) is in an `eval = FALSE` chunk, so it never runs.

No behavior change for users who have `MplusAutomation` installed.

Please let me know if I've got any of this wrong, for example if further guards are needed.
