### PR TITLE
Lower recommended number of nodes for interaction between endogenous and exogenous latent variables in LMS with quasi adaptive quadrature.

### DIFF
--- a/R/check_model_da.R
+++ b/R/check_model_da.R
@@ -107,7 +107,7 @@ checkNodesLms <- function(parTableMain,
                           method = "lms",
                           adaptive = FALSE,
                           minNodesXiXi   = if (!adaptive) 16 else 15,
-                          minNodesXiEta  = if (!adaptive) 32 else 32,
+                          minNodesXiEta  = if (!adaptive) 32 else 24,
                           minNodesEtaEta = if (!adaptive) 48 else 32) {
   if (method != "lms") return(NULL)
 


### PR DESCRIPTION
Requiring 32 nodes for interactions between exogenous and endogenous latent variables in the LMS approach is unnecessarily strict. Now lowered to 24.