### PR TITLE
Don't mix upper and lower case in generated mplus .inp, .out and .dat files

### DIFF
--- a/R/modsem_mplus.R
+++ b/R/modsem_mplus.R
@@ -725,9 +725,9 @@ cleanupMplusFiles <- function(fprefix) {
 }
 
 
-getMplusFilePrefix <- function(max.iter = 20) {
+getMplusFilePrefix <- function(max.iter = 20, base = "mpresults") {
   randid <- generateRandomCharId(n=12)
-  fprefix <- paste0("mplusResults", randid)
+  fprefix <- paste0(base, randid)
 
   if (!mplusFilePrefixExists(fprefix))
     return(fprefix)
@@ -746,4 +746,13 @@ getMplusFilePrefix <- function(max.iter = 20) {
   )
 
   fprefix
+}
+
+
+generateRandomCharId <- function(n = 36) {
+  # use only lower letters, as Mplus sometimes seem to convert upper case
+  # characters in the .inp file to lower characters in the .out file. In
+  # particular this seems to happen on Mplus 8.11 on Windows
+  chars <- c(letters, as.character(0:9))
+  paste0(sample(chars, size = n, replace = TRUE), collapse = "")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -848,9 +848,3 @@ std1 <- function(v) {
 
   (v - mu) / sigma
 }
-
-
-generateRandomCharId <- function(n = 36) {
-  chars <- c(letters, LETTERS, as.character(0:9))
-  paste0(sample(chars, size = n, replace = TRUE), collapse = "")
-}


### PR DESCRIPTION
`Mplus` under certain circumstances seems to convert upper characters in the `.inp` files to lower case characters in the `.out` file. This breaks the `cleanup` argument. To address this, we should always use lower case in the file prefix.