### PR TITLE
Fix sample size N in clustered robust QML standard errors

### DIFF
--- a/R/calc_se_da.R
+++ b/R/calc_se_da.R
@@ -462,8 +462,6 @@ calcOFIM_QML <- function(model, theta,
                          robust.se = FALSE,
                          cluster   = NULL,
                          cr1s      = TRUE) {
-  N <- sum(vapply(model$models, FUN.VALUE = numeric(1L), FUN = \(sub) sub$data$n))
-
   if (hessian) {
     # negative hessian (sign = -1)
     I <- calcHessian(model = model, theta = theta,
@@ -500,7 +498,7 @@ calcOFIM_QML <- function(model, theta,
 
   # Optional CR1S small-sample correction
   if (isTRUE(cr1s)) {
-    q <- ncol(S)
+    N <- nrow(S); q <- ncol(S)
     if (G > 1 && N > q)
       B <- B * (G / (G - 1)) * ((N - 1) / (N - q))
   }

--- a/R/calc_se_da.R
+++ b/R/calc_se_da.R
@@ -462,7 +462,7 @@ calcOFIM_QML <- function(model, theta,
                          robust.se = FALSE,
                          cluster   = NULL,
                          cr1s      = TRUE) {
-  N <- sum(vapply(model$models, FUN.VALUE = numeric(1L), FUN = \(sub) NROW(sub$data)))
+  N <- sum(vapply(model$models, FUN.VALUE = numeric(1L), FUN = \(sub) sub$data$n))
 
   if (hessian) {
     # negative hessian (sign = -1)


### PR DESCRIPTION
Hi Kjell,

`calcOFIM_QML()` gets the sample size from `NROW(sub$data)`, but `sub$data` is a list, not the data matrix. So `N` becomes the number of elements in the list (16) instead of the number of observations. This only affects the CR1S correction for clustered robust SEs: with `N = 16` the `N > q` check fails and the correction is silently skipped, so the SEs come out too small.

```diff
-  N <- sum(vapply(model$models, FUN.VALUE = numeric(1L), FUN = \(sub) NROW(sub$data)))
+  N <- sum(vapply(model$models, FUN.VALUE = numeric(1L), FUN = \(sub) sub$data$n))
```

**Reprex**

With the bug, `cr1s = TRUE` and `cr1s = FALSE` give identical SEs because the correction never runs:

```r
library(modsem)
data(oneInt)
oneInt$cid <- rep(1:40, each = nrow(oneInt) / 40)   # 40 clusters

m <- "
  X =~ x1 + x2 + x3
  Y =~ y1 + y2 + y3
  Z =~ z1 + z2 + z3
  Y ~ X + Z + X:Z
"
se <- function(fit) fit$parTable[fit$parTable$op == "~", "std.error"]

on  <- modsem(m, oneInt, method = "qml", robust.se = TRUE, cluster = "cid", cr1s = TRUE)
off <- modsem(m, oneInt, method = "qml", robust.se = TRUE, cluster = "cid", cr1s = FALSE)

round(se(on) / se(off), 4)
#> [1] 1.0204 1.0204 1.0204   # with the fix
#> [1] 1 1 1                  # before the fix
```

I came across this during a consultancy. I must confess I am not entirely sure about it, so please correct me if I am wrong. I didn't have the time to simulate yet.
